### PR TITLE
[BUGFIX] Fix endless loading spinner in TYPO3 backend

### DIFF
--- a/Classes/Backend/Form/Container/InlineCloudinaryControlContainer.php
+++ b/Classes/Backend/Form/Container/InlineCloudinaryControlContainer.php
@@ -20,11 +20,6 @@ class InlineCloudinaryControlContainer extends InlineControlContainer
 
     public function render()
     {
-        // We load here the cloudinary library
-        /** @var AssetCollector $assetCollector */
-        $assetCollector = GeneralUtility::makeInstance(AssetCollector::class);
-        $assetCollector->addJavaScript('media_library_cloudinary', 'https://media-library.cloudinary.com/global/all.js', []);
-
         /** @var PageRenderer $pageRenderer */
         $pageRenderer = GeneralUtility::makeInstance(PageRenderer::class);
         $pageRenderer->loadRequireJsModule('TYPO3/CMS/Cloudinary/CloudinaryMediaLibrary');

--- a/Resources/Public/JavaScript/CloudinaryMediaLibrary.js
+++ b/Resources/Public/JavaScript/CloudinaryMediaLibrary.js
@@ -6,6 +6,7 @@ define([
   'TYPO3/CMS/Backend/Utility/MessageUtility',
   'TYPO3/CMS/Backend/Modal',
   'TYPO3/CMS/Backend/Severity',
+  '//media-library.cloudinary.com/global/all.js',
 ], function ($, NProgress, MessageUtility, Modal, Severity) {
 
   let irreNewTimout;


### PR DESCRIPTION
Fix a race condition in the TYPO3 BE that occurred on backend forms with in line elements. Load the external cloudinary js library via requireJS to ensure its availability when the custom JS in the TYPO3 backend tries to access the global object.