### PR TITLE
[BUGFIX] Avoid type exception for missing images

### DIFF
--- a/Classes/Services/CloudinaryImageService.php
+++ b/Classes/Services/CloudinaryImageService.php
@@ -69,7 +69,7 @@ class CloudinaryImageService extends AbstractCloudinaryMediaService
     {
         $explicitData = $this->getExplicitData($file, $options);
 
-        return $explicitData['responsive_breakpoints'][0]['breakpoints'];
+        return $explicitData['responsive_breakpoints'][0]['breakpoints'] ?? [];
     }
 
     public function getSrcsetAttribute(array $breakpoints): string


### PR DESCRIPTION
The cloudinary extension tries to replace missing images with a default emergency fallback image. This may lead to invalid crop instructions for Cloudinary, as the emergency image may be smaller than the original image.

Recover from these Cloudinary exceptions by returning an empty image instead of dying with a type excpetion.