### PR TITLE
[BUGFIX] Use identifier_hash in CloudinaryScanService

### DIFF
--- a/Classes/Services/CloudinaryScanService.php
+++ b/Classes/Services/CloudinaryScanService.php
@@ -37,11 +37,6 @@ class CloudinaryScanService
 
     protected ResourceStorage $storage;
 
-    /**
-     * @var DriverInterface
-     */
-    protected mixed $driver;
-
     protected ?CloudinaryPathService $cloudinaryPathService = null;
 
     protected string $processedFolder = '_processed_';
@@ -66,7 +61,6 @@ class CloudinaryScanService
             throw new \Exception('Storage is not of type "cloudinary"', 1594714337);
         }
         $this->storage = $storage;
-        $this->driver = $this->getDriverFromStorage($storage);
         $this->io = $io;
     }
 
@@ -202,7 +196,7 @@ class CloudinaryScanService
             ->where(
                 $this->getQueryBuilder()->expr()->eq(
                     'identifier_hash',
-                    $query->expr()->literal($this->driver->hashIdentifier($fileIdentifier))
+                    $query->expr()->literal($this->storage->hashFileIdentifier($fileIdentifier)),
                 ),
                 $this->getQueryBuilder()->expr()->eq(
                     'storage',
@@ -277,19 +271,5 @@ class CloudinaryScanService
     {
         $this->additionalExpression = $additionalExpression;
         return $this;
-    }
-
-    /**
-     * Unfortunately there's no official API to fetch the driver used in a given Storage.
-     * This method uses Reflection to run the protected method `getDriver()` from the supplied `$storage`.
-     * We only need this to invoke the hashIdentifier() method
-     *
-     * @throws \ReflectionException
-     */
-    protected function getDriverFromStorage(ResourceStorage $storage): mixed
-    {
-        $reflectionMethod = new ReflectionMethod($storage, 'getDriver');
-        $reflectionMethod->setAccessible(true);
-        return $reflectionMethod->invoke($storage);
     }
 }

--- a/Classes/Services/CloudinaryScanService.php
+++ b/Classes/Services/CloudinaryScanService.php
@@ -37,7 +37,10 @@ class CloudinaryScanService
 
     protected ResourceStorage $storage;
 
-    protected DriverInterface $driver;
+    /**
+     * @var DriverInterface
+     */
+    protected mixed $driver;
 
     protected ?CloudinaryPathService $cloudinaryPathService = null;
 
@@ -283,7 +286,7 @@ class CloudinaryScanService
      *
      * @throws \ReflectionException
      */
-    protected function getDriverFromStorage(ResourceStorage $storage): DriverInterface
+    protected function getDriverFromStorage(ResourceStorage $storage): mixed
     {
         $reflectionMethod = new ReflectionMethod($storage, 'getDriver');
         $reflectionMethod->setAccessible(true);

--- a/Classes/Services/CloudinaryScanService.php
+++ b/Classes/Services/CloudinaryScanService.php
@@ -11,7 +11,6 @@ namespace Visol\Cloudinary\Services;
 
 use Cloudinary\Api\Admin\AdminApi;
 use Cloudinary\Api\Search\SearchApi;
-use ReflectionMethod;
 use TYPO3\CMS\Core\Exception;
 use TYPO3\CMS\Core\Log\Logger;
 use Symfony\Component\Console\Style\SymfonyStyle;
@@ -19,7 +18,6 @@ use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 use TYPO3\CMS\Core\Log\LogLevel;
 use TYPO3\CMS\Core\Log\LogManager;
-use TYPO3\CMS\Core\Resource\Driver\DriverInterface;
 use TYPO3\CMS\Core\Resource\ResourceStorage;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use Visol\Cloudinary\Driver\CloudinaryDriver;

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,6 +6,7 @@ parameters:
         - Classes
         - Configuration
     checkMissingIterableValueType: false
+    checkGenericClassInNonGenericObjectType: false
     reportUnmatchedIgnoredErrors: false
     ignoreErrors:
         -

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,7 +6,6 @@ parameters:
         - Classes
         - Configuration
     checkMissingIterableValueType: false
-    checkGenericClassInNonGenericObjectType: false
     reportUnmatchedIgnoredErrors: false
     ignoreErrors:
         -


### PR DESCRIPTION
The `fileExistsInStorage()` method currently performs a SQL query to count records, but suffers from slow performance due to the absence of an index on the `identifier` field. This results in a full table scan.

To address this issue, this commit refactors the method to utilize the pre-existing `identifier_hash` field, specifically designed for efficient data searches.