### PR TITLE
[BUGFIX] Use identifier_hash in CloudinaryScanService (#38)

### DIFF
--- a/Classes/Services/CloudinaryScanService.php
+++ b/Classes/Services/CloudinaryScanService.php
@@ -221,8 +221,8 @@ class CloudinaryScanService
             ->from('sys_file')
             ->where(
                 $this->getQueryBuilder()->expr()->eq(
-                    'identifier',
-                    $query->expr()->literal($fileIdentifier)
+                    'identifier_hash',
+                    $query->expr()->literal($this->storage->hashFileIdentifier($fileIdentifier)),
                 ),
                 $this->getQueryBuilder()->expr()->eq(
                     'storage',


### PR DESCRIPTION
* [BUGFIX] Use identifier_hash in CloudinaryScanService

The `fileExistsInStorage()` method currently performs a SQL query to count records, but suffers from slow performance due to the absence of an index on the `identifier` field. This results in a full table scan.

To address this issue, this commit refactors the method to utilize the pre-existing `identifier_hash` field, specifically designed for efficient data searches.