### PR TITLE
[TASK] JB-1250 Webhook: Speed up file lookups

### DIFF
--- a/Classes/Controller/CloudinaryWebHookController.php
+++ b/Classes/Controller/CloudinaryWebHookController.php
@@ -221,13 +221,14 @@ class CloudinaryWebHookController extends ActionController
     protected function getFile(array $cloudinaryResource): File
     {
         $fileIdentifier = $this->cloudinaryPathService->computeFileIdentifier($cloudinaryResource);
+        $fileIdentifierHash = $this->storage->hashFileIdentifier($fileIdentifier);
         $tableName = 'sys_file';
         $q = $this->getQueryBuilder($tableName);
         $fileRecord = $q->select('*')
             ->from($tableName)
             ->where(
                 $q->expr()->eq('storage', $this->storage->getUid()),
-                $q->expr()->eq('identifier', $q->expr()->literal($fileIdentifier))
+                $q->expr()->eq('identifier_hash', $q->expr()->literal($fileIdentifierHash))
             )
             ->execute()
             ->fetchAssociative();


### PR DESCRIPTION
Use an existing database index when looking up files in the Cloudinary 
webhook controller. Query the files table with the identifier hash 
instead of the full identifier.