### PR TITLE
[BUGFIX] JB-1301 Fix processed files on clouds with cnames

### DIFF
--- a/Classes/EventHandlers/BeforeFileProcessingEventHandler.php
+++ b/Classes/EventHandlers/BeforeFileProcessingEventHandler.php
@@ -14,7 +14,9 @@ use TYPO3\CMS\Core\Resource\File;
 use TYPO3\CMS\Core\Resource\ProcessedFileRepository;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use Visol\Cloudinary\Driver\CloudinaryDriver;
+use Visol\Cloudinary\Exceptions\InvalidResourceUrlException;
 use Visol\Cloudinary\Services\CloudinaryImageService;
+use Visol\Cloudinary\Services\ConfigurationService;
 
 final class BeforeFileProcessingEventHandler
 {
@@ -54,11 +56,15 @@ final class BeforeFileProcessingEventHandler
             ]
         );
         $url = $explicitData['eager'][0]['secure_url'];
+        $publicBaseUrl = $driver->getPublicBaseUrl();
 
-        $parts = parse_url($url);
-        $path = $parts['path'] ?? '';
+        if (! str_starts_with($url, $publicBaseUrl)) {
+            throw new InvalidResourceUrlException($url, $publicBaseUrl, 1709284880259);
+        }
+
+        $identifier = CloudinaryDriver::PROCESSEDFILE_IDENTIFIER_PREFIX . substr($url, strlen($publicBaseUrl));
         $processedFile->setName(basename($url));
-        $processedFile->setIdentifier('PROCESSEDFILE' . $path);
+        $processedFile->setIdentifier($identifier);
 
         $processedFile->updateProperties([
             'width' => $explicitData['eager'][0]['width'],
@@ -72,5 +78,11 @@ final class BeforeFileProcessingEventHandler
     public function getCloudinaryImageService(): CloudinaryImageService
     {
         return GeneralUtility::makeInstance(CloudinaryImageService::class);
+    }
+
+    protected function getCloudNameForFile(File $file): string
+    {
+        $configurationService = GeneralUtility::makeInstance(ConfigurationService::class, $file->getStorage()->getConfiguration());
+        return $configurationService->get('cloudName');
     }
 }

--- a/Classes/Exceptions/InvalidResourceUrlException.php
+++ b/Classes/Exceptions/InvalidResourceUrlException.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Visol\Cloudinary\Exceptions;
+
+class InvalidResourceUrlException extends \Exception
+{
+    public function __construct(
+        protected string $resourceUrl,
+        protected string $cloudBaseUrl,
+        int $code
+    ) {
+        $message = sprintf('Resource URL "%s" ist not in cloud base URL "%s"', $resourceUrl, $cloudBaseUrl);
+        parent::__construct($message, $code);
+    }
+}


### PR DESCRIPTION
Fix a bug where processed files would not be recognized if the cloudinary cloud uses a cname.

Remove the cloud name from the processed file identifier